### PR TITLE
Explicit imports

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,20 @@
 import os
 from pathlib import Path
 
-from fasthtml.common import *  # noqa: F403
+from fasthtml.common import (
+    H3,
+    Button,
+    Div,
+    Form,
+    Input,
+    Label,
+    Li,
+    P,
+    Titled,
+    Ul,
+    fast_app,
+    serve,
+)
 
 app, rt = fast_app()
 


### PR DESCRIPTION
# Issue

`import *` would confuse PyCharm that other imports are not used.

![image](https://github.com/user-attachments/assets/97f5b15b-eb83-4b49-9b04-8d41c0f02748)
